### PR TITLE
update to 1.20.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,20 +4,8 @@ set -xeuo pipefail
 
 EXTRA_ARGS=" --with-rdmacm=${PREFIX} --with-verbs=${PREFIX}"
 
-if [[ "${cuda_compiler_version}" =~ 12.* ]]; then
+if [[ "${cuda_compiler_version}" != "None" ]]; then
   EXTRA_ARGS="${EXTRA_ARGS} --with-cuda=${PREFIX}"
-elif [[ "${cuda_compiler_version}" != "None" ]]; then
-  if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" == "1" ]]; then
-    if [[ "${target_platform}" == "linux-aarch64" ]]; then
-        CUDA_HOME="${CUDA_HOME}/targets/sbsa-linux"
-    elif [[ "${target_platform}" == "linux-ppc64le" ]]; then
-        CUDA_HOME="${CUDA_HOME}/targets/ppc64le-linux"
-    else
-        echo "Unsupported target_platform: ${target_platform}"
-        exit 1
-    fi
-  fi
-  EXTRA_ARGS="${EXTRA_ARGS} --with-cuda=${CUDA_HOME}"
 fi
 
 ./contrib/configure-release \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,5 @@
+## Overrides aggregate CBC (12.4) — CUDA 12.4 is incompatible with GCC 14.
+## cuda_compiler repeated here to ensure correct variant pairing.
 cuda_compiler:                     # [linux]
   - cuda-nvcc                      # [linux]
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,7 @@
+cuda_compiler:                     # [linux]
+  - cuda-nvcc                      # [linux]
+
+cuda_compiler_version:             # [linux]
+  - 12.9                           # [linux]
+  - 13.0                           # [linux]
+  - 13.1                           # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "ucx" %}
-{% set version = "1.18.1" %}
+{% set version = "1.20.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/open{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8018dd75f11b5e8d6e57dcdb5b798d2c1f000982c353efde1f3170025c6c3b4c
+  url: https://github.com/openucx/ucx/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7c8a6093cada179aa1d851b83625e3b25ed5658966e309de5118c27a038c7ef9
 
 build:
   number: 0
@@ -38,9 +38,8 @@ requirements:
     - cuda-version {{ cuda_compiler_version }}
     - cuda-cudart-dev  # [cuda_compiler == "cuda-nvcc"]
     - cuda-nvml-dev  # [cuda_compiler == "cuda-nvcc"]
-    - rdma-core 58.0
+    - rdma-core
   run_constrained:
-    - {{ pin_compatible("cuda-version", lower_bound="11.2") }}  # [cuda_compiler == "nvcc"]
     - {{ pin_compatible("cuda-version", min_pin="x") }}  # [cuda_compiler == "cuda-nvcc"]
     # The actual version constraint comes from cuda-version, so below we explicit list
     # them only to codify that these are expected (but optional) dependencies when CUDA

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/openucx/ucx/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
+  url: https://github.com/open{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: 7c8a6093cada179aa1d851b83625e3b25ed5658966e309de5118c27a038c7ef9
 
 build:

--- a/recipe/ucx-post-link.sh
+++ b/recipe/ucx-post-link.sh
@@ -5,8 +5,8 @@ cat << EOF >> "${PREFIX}/.messages.txt"
 To enable CUDA support, UCX requires the CUDA Runtime library (libcudart).
 The library can be installed with the appropriate command below:
 
-* For CUDA 11, run:    conda install cudatoolkit cuda-version=11
 * For CUDA 12, run:    conda install cuda-cudart cuda-version=12
+* For CUDA 13, run:    conda install cuda-cudart cuda-version=13
 
 If any of the packages you requested use CUDA then CUDA should already
 have been installed for you.


### PR DESCRIPTION
ucx 1.20.0

**Destination channel:** defaults

### Links

- [PKG-11421](https://anaconda.atlassian.net/browse/PKG-11421)
- [Upstream repository](https://github.com/openucx/ucx)
- [Upstream changelog/diff](https://github.com/openucx/ucx/releases/tag/v1.20.0)
- Relevant dependency PRs: N/A

### Explanation of changes:

- Update UCX from 1.18.1 to 1.20.0
- Add local `conda_build_config.yaml` for CUDA 12.9, 13.0, and 13.1 (aggregate default 12.4 incompatible with GCC 14)
- Simplify `build.sh` CUDA detection — remove legacy CUDA 11 cross-compilation paths (matches conda-forge upstream)
- Unpin rdma-core host dep (aggregate CBC provides pin at 61.0, was hardcoded to 58.0)
- Remove legacy CUDA 11 `nvcc` run_constrained entry

[PKG-11421]: https://anaconda.atlassian.net/browse/PKG-11421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ