### PR TITLE
Explicitly include libgomp

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7c8a6093cada179aa1d851b83625e3b25ed5658966e309de5118c27a038c7ef9
 
 build:
-  number: 0
+  number: 1
   skip: True  # [(not linux) or cuda_compiler_version in (undefined, "None", "12.6")]
   ignore_run_exports_from:
     - {{ compiler("cuda") }}
@@ -38,7 +38,10 @@ requirements:
     - cuda-version {{ cuda_compiler_version }}
     - cuda-cudart-dev  # [cuda_compiler == "cuda-nvcc"]
     - cuda-nvml-dev  # [cuda_compiler == "cuda-nvcc"]
-    - rdma-core
+    - rdma-core 58.0
+    - libgomp # [linux]
+  run:
+    - libgomp # [linux]
   run_constrained:
     - {{ pin_compatible("cuda-version", min_pin="x") }}  # [cuda_compiler == "cuda-nvcc"]
     # The actual version constraint comes from cuda-version, so below we explicit list


### PR DESCRIPTION
ucx openmp rebuild

**Destination channel:** defaults

### Links

- [PKG-14743](https://anaconda.atlassian.net/browse/PKG-14743) 


### Explanation of changes:

- Explicitly link to libgomp 

## Note
The GIthub UI didn't update, the graph is green: https://package-build.anaconda.com/v1/graph/d0d4d355-715e-43d8-afb0-b125d5d73276

[OpenMP usage Audit](https://docs.google.com/spreadsheets/d/1Pln3E1WKlhasfR5NNyT9juhXrcM_63bQpAZRHDjNHtc/edit?usp=sharing)


[PKG-14743]: https://anaconda.atlassian.net/browse/PKG-14743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ